### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build - App
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3.1.0
 
       - name: Azure authentication
         uses: azure/login@v1
@@ -57,7 +57,7 @@ jobs:
     name: Build - Database
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3.1.0
 
       - name: setup-msbuild
         uses: microsoft/setup-msbuild@v1
@@ -69,7 +69,7 @@ jobs:
         run: Copy-Item "database/bin/Debug/database.dacpac" -Destination "database.dacpac"
 
       - name: Upload dacpac as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.1
         with:
           name: dacpac
           path: database.dacpac
@@ -78,7 +78,7 @@ jobs:
     name: Build - Infrastructure
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3.1.0
 
       - name: Azure authentication
         uses: azure/login@v1
@@ -114,7 +114,7 @@ jobs:
     needs: [build-app, build-database, build-iac]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3.1.0
 
       - name: Azure authentication
         uses: azure/login@v1
@@ -140,7 +140,7 @@ jobs:
                          dbPassword='${{ secrets.DBPASSWORD }}' \
                          devEnv='${{ env.DEVENV }}'
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3.0.1
         name: download dacpac from build
         with:
           name: dacpac
@@ -174,7 +174,7 @@ jobs:
       DEVENV: false
     needs: [deploy-dev]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3.1.0
 
       - name: Azure authentication
         uses: azure/login@v1
@@ -195,7 +195,7 @@ jobs:
                          dbPassword='${{ secrets.DBPASSWORD }}' \
                          devEnv='${{ env.DEVENV }}'
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3.0.1
         name: Download dacpac from build
         with:
           name: dacpac
@@ -238,8 +238,8 @@ jobs:
         working-directory: e2e-tests      
     needs: [deploy-test]
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-node@v3.5.1
         with:
           node-version: "14.x"
 
@@ -252,12 +252,12 @@ jobs:
           HOME=/root npx playwright test
 
       - name: Create test summary
-        uses: test-summary/action@dist
+        uses: test-summary/action@v2.0
         if: always()
         with:
           paths: e2e-tests/results/junit.xml
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3.1.1
         name: Upload HTML report
         if: always()
         with:
@@ -274,7 +274,7 @@ jobs:
       ENVIRONMENTNAME: test
     needs: [deploy-test, test-e2e]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3.1.0
 
       - name: Azure authentication
         uses: azure/login@v1
@@ -306,7 +306,7 @@ jobs:
       DEVENV: false
     needs: [deploy-test, test-load, test-e2e]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3.1.0
 
       - name: Azure authentication
         uses: azure/login@v1
@@ -327,7 +327,7 @@ jobs:
                          dbPassword='${{ secrets.DBPASSWORD }}' \
                          devEnv='${{ env.DEVENV }}'
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3.0.1
         name: Download dacpac from build
         with:
           name: dacpac

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
         with:
           token: ${{ secrets.UPDATER_SECRET }}
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[test-summary/action](https://github.com/test-summary/action)** published a new release **[v2.0](https://github.com/test-summary/action/releases/tag/v2.0)** on 2022-10-14T12:51:57Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v3.1.1](https://github.com/actions/upload-artifact/releases/tag/v3.1.1)** on 2022-10-21T19:20:02Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v3.0.1](https://github.com/actions/download-artifact/releases/tag/v3.0.1)** on 2022-10-20T23:34:13Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.1.0](https://github.com/actions/checkout/releases/tag/v3.1.0)** on 2022-10-04T09:40:24Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v3.5.1](https://github.com/actions/setup-node/releases/tag/v3.5.1)** on 2022-10-13T12:19:17Z
